### PR TITLE
Allow a default value to be returned when property is not found by BeanELResolver.

### DIFF
--- a/modules/api/src/main/java/javax/el/BeanELResolver.java
+++ b/modules/api/src/main/java/javax/el/BeanELResolver.java
@@ -264,7 +264,13 @@ public class BeanELResolver extends ELResolver {
 		}
 		Class<?> result = null;
 		if (isResolvable(base)) {
-			result = toBeanProperty(base, property).getPropertyType();
+            
+            // result = toBeanProperty(base, property).getPropertyType();
+            BeanProperty beanProperty = toBeanProperty(base, property);
+            if( beanProperty == null ){
+                // We could return null...?  Or have some `Class onPropertyNotFoundType`...?
+                throw new PropertyNotFoundException("Could not find property " + property + " in " + base.getClass());
+            }
 			context.setPropertyResolved(true);
 		}
 		return result;
@@ -304,7 +310,14 @@ public class BeanELResolver extends ELResolver {
 		}
 		Object result = null;
 		if (isResolvable(base)) {
-			Method method = toBeanProperty(base, property).getReadMethod();
+            BeanProperty beanProperty = toBeanProperty(base, property);
+            if( beanProperty == null ){
+                Object ret = this.onPropertyNotFoundRead(base, property); // May throw, and if we need to do:
+                context.setPropertyResolved(true);
+                return ret;
+            }
+            
+			Method method = beanProperty.getReadMethod();
 			if (method == null) {
 				throw new PropertyNotFoundException("Cannot read property " + property);
 			}
@@ -320,6 +333,12 @@ public class BeanELResolver extends ELResolver {
 		return result;
 	}
 
+    /** Overrides may throw or return custom object / string. */
+    protected Object onPropertyNotFoundRead( Object base, Object property ) {
+        throw new PropertyNotFoundException("Could not find property " + property + " in " + base.getClass());
+    }
+    
+    
 	/**
 	 * If the base object is not null, returns whether a call to
 	 * {@link #setValue(ELContext, Object, Object, Object)} will always fail. If the base is not
@@ -352,7 +371,10 @@ public class BeanELResolver extends ELResolver {
 		}
 		boolean result = readOnly;
 		if (isResolvable(base)) {
-			result |= toBeanProperty(base, property).isReadOnly();
+            BeanProperty beanProperty = toBeanProperty(base, property);
+            if( null == beanProperty )  result = false;
+            else
+                result |= toBeanProperty(base, property).isReadOnly();
 			context.setPropertyResolved(true);
 		}
 		return result;
@@ -398,7 +420,11 @@ public class BeanELResolver extends ELResolver {
 			if (readOnly) {
 				throw new PropertyNotWritableException("resolver is read-only");
 			}
-			Method method = toBeanProperty(base, property).getWriteMethod();
+            final BeanProperty beanProperty = toBeanProperty(base, property);
+            if( beanProperty == null ){
+                throw new PropertyNotFoundException("Could not find property " + property + " in " + base.getClass());
+            }
+			Method method = beanProperty.getWriteMethod();
 			if (method == null) {
 				throw new PropertyNotWritableException("Cannot write property: " + property);
 			}
@@ -628,12 +654,9 @@ public class BeanELResolver extends ELResolver {
 			}
 		}
 		BeanProperty beanProperty = property == null ? null : beanProperties.getBeanProperty(property.toString());
-		if (beanProperty == null) {
-			throw new PropertyNotFoundException("Could not find property " + property + " in " + base.getClass());
-		}
 		return beanProperty;
 	}
-
+    
 	/**
 	 * This method is not part of the API, though it can be used (reflectively) by clients of this
 	 * class to remove entries from the cache when the beans are being unloaded.


### PR DESCRIPTION
It would be better to handle it on some higher level, probably AST,  but I'm already happy with this for my purposes.

Usage:

```
/**
 *  Puts a custom default string in place of unresolved property, instead of throwing an ex.
 */
public static class BeanELDefaultStringResolver extends BeanELOpenResolver {

    private final String defaultString;

    public BeanELDefaultStringResolver( String defaultString ) {
        this.defaultString = defaultString;
    }

    @Override protected Object onPropertyNotFoundRead( Object base, Object property ) {
        return this.defaultString;
    }
}
```
